### PR TITLE
[oikos] Delete Hereditas from _journals.tab

### DIFF
--- a/generate_dependent_styles/oikos/_journals.tab
+++ b/generate_dependent_styles/oikos/_journals.tab
@@ -1,6 +1,5 @@
 Title	ISSN	eISSN	Documentation
 Ecography	0906-7590	1600-0587	http://www.ecography.org/authors/author-guidelines
-Hereditas	0018-0661	1601-5223	http://www.hereditasjournal.org/authors/author-guidelines
 Lindbergia		2001-5909	http://www.lindbergia.org/authors/author-guidelines
 Nordic Journal of Botany	0107-055X	1756-1051	http://www.nordicjbotany.org/authors/author-guidelines
 Wildlife Biology	0909-6396	1903-220X	http://www.wildlifebiology.org/authors/author-guidelines


### PR DESCRIPTION
The journal is now published by Springer und BioMedCentral: http://hereditasjournal.biomedcentral.com/

For the publication history see http://dispatch.opac.d-nb.de/DB=1.1/SRT=YOP/CMD?ACT=SRCHA&IKT=8506&TRM=2092962-6