### PR TITLE
[Elsevier] Skip "Journal of ultrasound"

### DIFF
--- a/generate_dependent_styles/elsevier/_skip.txt
+++ b/generate_dependent_styles/elsevier/_skip.txt
@@ -19,3 +19,6 @@ pain
 cell
 journal-of-investigative-dermatology
 medical-journal-of-australia
+
+# Moved to Springer
+journal-of-ultrasound


### PR DESCRIPTION
The journal was moved to Springer in 2012/2013, see

http://dispatch.opac.d-nb.de/DB=1.1/SRT=YOP/LNG=DU/CMD?ACT=SRCHA&IKT=8506&TRM=2365426-0